### PR TITLE
Making the sizing for the octicon a little bit more flexible

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The `Octicon` class takes a hash of arguments to construct the icon you want
 #### Options
 
 * `:symbol` _(required)_ - This is the name of the octicon you want to use. For example `alert`. [Full list of icons][octicons-docs]
-* `:size` - This will help output 16 or 32 sized icons. You can also pass an Integer to this, for other sizes
+* `:size` - This will help output 16 or 32 sized icons. if you pass "large" the icon will be double the size. You can also pass an number and the icon will be scaled properly.
 * `:width`, `:height` - width and height are exact sizes, if you have an odd shape like the gist logo, pass in exact dimensions
 
 Everything else passed in through the options hash will be treated as html attributes and added to the svg tag.

--- a/lib/octicons/octicon.rb
+++ b/lib/octicons/octicon.rb
@@ -70,24 +70,24 @@ module Octicons
 
       # When size is an integer
       elsif @options[:size].is_a?(Integer) || !!(@options[:size] =~ /\A[0-9]+\z/)
-        size[:width] = (@options[:size].to_i * @width) / @height
+        size[:width]  = calculate_width(@options[:size])
         size[:height] = @options[:size]
 
         # Specific size
-      elsif !@options[:width].nil? && !@options[:height].nil?
-        size[:width] = @options[:width]
-        size[:height] = @options[:height]
-
-      elsif !@options[:height].nil?
-        size[:width] = (@options[:height].to_i * @width) / @height
-        size[:height] = @options[:height]
-
-      elsif !@options[:width].nil?
-        size[:width] = @options[:width]
-        size[:height] = (@options[:width].to_i * @height) / @width
+      elsif !@options[:width].nil? || !@options[:height].nil?
+        size[:width]  = @options[:width].nil?  ? calculate_width(@options[:height]) : @options[:width]
+        size[:height] = @options[:height].nil? ? calculate_height(@options[:width]) : @options[:height]
       end
 
       size
+    end
+
+    def calculate_width(height)
+      (height.to_i * @width) / @height
+    end
+
+    def calculate_height(width)
+      (width.to_i * @height) / @width
     end
   end
 end

--- a/lib/octicons/octicon.rb
+++ b/lib/octicons/octicon.rb
@@ -7,66 +7,79 @@ module Octicons
         @path = symbol[:path]
         @width = symbol[:width]
         @height = symbol[:height]
-        @html_options = @options.reject { |d| [:symbol, :tag, :size].include? d }
 
-        css_class
-        compute_size
-        accessible
+        # create html_options from options, except for a few
+        @html_options = @options.reject { |d| [:symbol, :size].include? d }
+        @html_options.merge!({
+          :class => classes,
+          :viewBox => viewbox,
+          :version => "1.1"
+        })
+        @html_options.merge!(size)
+        @html_options.merge!(a11y)
       else
         raise "Couldn't find octicon symbol for #{options[:symbol].inspect}"
       end
     end
 
     def to_svg
-      "<svg #{html_attrs}>#{@path}</svg>"
+      "<svg #{html_attributes}>#{@path}</svg>"
     end
 
     private
 
-    def html_attrs
+    def html_attributes
       attrs = ""
       @html_options.each { |attr, value| attrs += "#{attr}=\"#{value}\" " }
       attrs.strip
     end
 
     # add some accessibility features to svg
-    def accessible
-      @html_options[:version] = "1.1"
+    def a11y
+      accessible = {}
 
-      if @html_options[:'aria-label'].nil?
-        @html_options[:'aria-hidden'] = "true"
+      if @options[:'aria-label'].nil?
+        accessible[:'aria-hidden'] = "true"
       else
-        @html_options[:role] = "img"
+        accessible[:role] = "img"
       end
+
+      accessible
     end
 
     # prepare the octicon class
-    def css_class
-      @html_options[:class] = "octicon octicon-#{@options[:symbol]} #{@options[:class]} ".strip
+    def classes
+      "octicon octicon-#{@options[:symbol]} #{@options[:class]} ".strip
+    end
+
+    def viewbox
+      "0 0 #{@width} #{@height}"
     end
 
     # determine the height and width of the octicon based on :size option
-    def compute_size
+    def size
+      size = {
+        :width => @width,
+        :height => @height
+      }
 
-      @html_options[:viewBox] = "0 0 #{@width} #{@height}"
-
+      # Specific size
       if !@options[:width].nil? && !@options[:height].nil?
-        @html_options[:width] = @options[:width]
-        @html_options[:height] = @options[:height]
+        size[:width] = @options[:width]
+        size[:height] = @options[:height]
 
+      # When size is "large"
       elsif @options[:size] == "large"
-        @html_options[:width] = 2 * @width
-        @html_options[:height] = 2 * @height
+        size[:width] = 2 * @width
+        size[:height] = 2 * @height
 
+      # When size is an integer
       elsif @options[:size].is_a? Integer
-        @html_options[:width] = (@options[:size] * @width) / @height
-        @html_options[:height] = @options[:size]
-
-      else
-        @html_options[:width] = @width
-        @html_options[:height] = @height
-
+        size[:width] = (@options[:size] * @width) / @height
+        size[:height] = @options[:size]
       end
+
+      size
     end
   end
 end

--- a/lib/octicons/octicon.rb
+++ b/lib/octicons/octicon.rb
@@ -11,7 +11,7 @@ module Octicons
         # create html_options from options, except for a few
         @html_options = @options.reject { |d| [:symbol, :size].include? d }
         @html_options.merge!({
-          :class => classes,
+          :class   => classes,
           :viewBox => viewbox,
           :version => "1.1"
         })
@@ -63,20 +63,28 @@ module Octicons
         :height => @height
       }
 
-      # Specific size
-      if !@options[:width].nil? && !@options[:height].nil?
-        size[:width] = @options[:width]
-        size[:height] = @options[:height]
-
       # When size is "large"
-      elsif @options[:size] == "large"
+      if @options[:size] == "large"
         size[:width] = 2 * @width
         size[:height] = 2 * @height
 
       # When size is an integer
-      elsif @options[:size].is_a? Integer
-        size[:width] = (@options[:size] * @width) / @height
+      elsif @options[:size].is_a?(Integer) || !!(@options[:size] =~ /\A[0-9]+\z/)
+        size[:width] = (@options[:size].to_i * @width) / @height
         size[:height] = @options[:size]
+
+        # Specific size
+      elsif !@options[:width].nil? && !@options[:height].nil?
+        size[:width] = @options[:width]
+        size[:height] = @options[:height]
+
+      elsif !@options[:height].nil?
+        size[:width] = (@options[:height].to_i * @width) / @height
+        size[:height] = @options[:height]
+
+      elsif !@options[:width].nil?
+        size[:width] = @options[:width]
+        size[:height] = (@options[:width].to_i * @height) / @width
       end
 
       size

--- a/test/octicon_test.rb
+++ b/test/octicon_test.rb
@@ -16,9 +16,9 @@ describe Octicons::Octicon do
 
   describe "html_attributes" do
     it "includes other html attributes" do
-      icon = octicon(:symbol => "x", :'aria-label' => "Close", :disabled => "true")
+      icon = octicon(:symbol => "x", :foo => "bar", :disabled => "true")
       assert_includes icon.to_svg, "disabled=\"true\""
-      assert_includes icon.to_svg, "aria-label=\"Close\""
+      assert_includes icon.to_svg, "foo=\"bar\""
     end
   end
 

--- a/test/octicon_test.rb
+++ b/test/octicon_test.rb
@@ -7,20 +7,26 @@ describe Octicons::Octicon do
     end
   end
 
-  it "includes classes passed in" do
-    icon = octicon(:symbol => "x", :class => "text-closed")
-    assert_includes icon.to_svg, "class=\"octicon octicon-x text-closed\""
+  describe "viewBox" do
+    it "always has a viewBox" do
+      icon = octicon(:symbol => "x")
+      assert_includes icon.to_svg, "viewBox=\"0 0 12 16\""
+    end
   end
 
-  it "includes other html attributes" do
-    icon = octicon(:symbol => "x", :'aria-label' => "Close", :disabled => "true")
-    assert_includes icon.to_svg, "disabled=\"true\""
-    assert_includes icon.to_svg, "aria-label=\"Close\""
+  describe "html_attributes" do
+    it "includes other html attributes" do
+      icon = octicon(:symbol => "x", :'aria-label' => "Close", :disabled => "true")
+      assert_includes icon.to_svg, "disabled=\"true\""
+      assert_includes icon.to_svg, "aria-label=\"Close\""
+    end
   end
 
-  it "always has a viewBox" do
-    icon = octicon(:symbol => "x")
-    assert_includes icon.to_svg, "viewBox=\"0 0 12 16\""
+  describe "classes" do
+    it "includes classes passed in" do
+      icon = octicon(:symbol => "x", :class => "text-closed")
+      assert_includes icon.to_svg, "class=\"octicon octicon-x text-closed\""
+    end
   end
 
   describe "size" do
@@ -41,6 +47,36 @@ describe Octicons::Octicon do
       assert_includes icon.to_svg, "width=\"45\""
     end
 
+    it "converts number string size to integer" do
+      icon = octicon(:symbol => "x", :size => "60")
+      assert_includes icon.to_svg, "height=\"60\""
+      assert_includes icon.to_svg, "width=\"45\""
+    end
+
+    it "converts number string height to integer" do
+      icon = octicon(:symbol => "x", :height => "60")
+      assert_includes icon.to_svg, "height=\"60\""
+      assert_includes icon.to_svg, "width=\"45\""
+    end
+
+    it "converts number height to integer" do
+      icon = octicon(:symbol => "x", :height => 60)
+      assert_includes icon.to_svg, "height=\"60\""
+      assert_includes icon.to_svg, "width=\"45\""
+    end
+
+    it "converts number string width to integer" do
+      icon = octicon(:symbol => "x", :width => "45")
+      assert_includes icon.to_svg, "height=\"60\""
+      assert_includes icon.to_svg, "width=\"45\""
+    end
+
+    it "converts number width to integer" do
+      icon = octicon(:symbol => "x", :width => 45)
+      assert_includes icon.to_svg, "height=\"60\""
+      assert_includes icon.to_svg, "width=\"45\""
+    end
+
     it "with height and width passed in" do
       icon = octicon(:symbol => "x", :width => 60, :height => 60)
       assert_includes icon.to_svg, "width=\"60\""
@@ -48,7 +84,7 @@ describe Octicons::Octicon do
     end
   end
 
-  describe "accessibility" do
+  describe "a11y" do
     it "includes attributes" do
       icon = octicon(:symbol => "x", :'aria-label' => "Close")
       assert_includes icon.to_svg, "role=\"img\""

--- a/test/octicon_test.rb
+++ b/test/octicon_test.rb
@@ -18,18 +18,18 @@ describe Octicons::Octicon do
     assert_includes icon.to_svg, "aria-label=\"Close\""
   end
 
-  it "always has width and height" do
-    icon = octicon(:symbol => "x")
-    assert_includes icon.to_svg, "height=\"16\""
-    assert_includes icon.to_svg, "width=\"12\""
-  end
-
   it "always has a viewBox" do
     icon = octicon(:symbol => "x")
     assert_includes icon.to_svg, "viewBox=\"0 0 12 16\""
   end
 
   describe "size" do
+    it "always has width and height" do
+      icon = octicon(:symbol => "x")
+      assert_includes icon.to_svg, "height=\"16\""
+      assert_includes icon.to_svg, "width=\"12\""
+    end
+
     it "correctly using the word large" do
       icon = octicon(:symbol => "x", :size => "large")
       assert_includes icon.to_svg, "height=\"32\""

--- a/test/octicons_test.rb
+++ b/test/octicons_test.rb
@@ -3,5 +3,6 @@ require_relative "./helper"
 describe Octicons do
   it "loads all icons on initialization" do
     refute_equal 0, Octicons::OCTICON_SYMBOLS.length
+    assert_equal Dir[Octicons::OCTICONS_SVG_PATH].length, Octicons::OCTICON_SYMBOLS.length
   end
 end


### PR DESCRIPTION
This makes the sizing more flexible, Allowing `:size, :width, :height` to be Integers or Strings.

I also did some cleanup and refactoring on the other methods in `Octicon`
