### PR TITLE
Making some of the icon attributes readable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# HEAD
+
+- Adding: attr_reader for `:path, :html_options, :width, :height`
+
+# 1.1.0
+
+- Added new octicons version 4.1.0
+
+# 1.0.0
+
+- First release, it's an octicons gem.

--- a/lib/octicons/octicon.rb
+++ b/lib/octicons/octicon.rb
@@ -1,6 +1,8 @@
 module Octicons
   class Octicon
 
+    attr_reader :path, :html_options, :width, :height
+
     def initialize(options)
       @options = options
       if symbol = Octicons::OCTICON_SYMBOLS[@options[:symbol]]

--- a/test/octicon_test.rb
+++ b/test/octicon_test.rb
@@ -7,6 +7,14 @@ describe Octicons::Octicon do
     end
   end
 
+  it "the attributes are readable" do
+    icon = octicon(:symbol => "x")
+    assert icon.path
+    assert icon.html_options
+    assert_equal 12, icon.width
+    assert_equal 16, icon.height
+  end
+
   describe "viewBox" do
     it "always has a viewBox" do
       icon = octicon(:symbol => "x")


### PR DESCRIPTION
I need these attributes readable so I can read them into the [octicons_helper](https://github.com/primer/octicons_helper) rails gem and construct a content tag.
